### PR TITLE
Fixed rebar.config to not use the git account for github.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,10 +20,10 @@
 ]}.
 {deps, [
   {lager,       ".*",  {git, "git://github.com/basho/lager.git",     "2.0.3"}},
-  {sync,        "0.*", {git, "git@github.com:rustyio/sync.git",      "HEAD"}},
-  {jiffy,       ".*",  {git, "git@github.com:davisp/jiffy.git",      "0.13.2"}},
-  {shotgun,     ".*",  {git, "git@github.com:inaka/shotgun",         "0.1.4"}},
-  {worker_pool, ".*",  {git, "git@github.com:inaka/worker_pool.git", "1.0"}}
+  {sync,        "0.*", {git, "git://github.com/rustyio/sync.git",      "HEAD"}},
+  {jiffy,       ".*",  {git, "git://github.com/davisp/jiffy.git",      "0.13.2"}},
+  {shotgun,     ".*",  {git, "git://github.com/inaka/shotgun",         "0.1.4"}},
+  {worker_pool, ".*",  {git, "git://github.com/inaka/worker_pool.git", "1.0"}}
 ]}.
 {xref_warnings, true}.
 {xref_checks, [undefined_function_calls, undefined_functions, locals_not_used, deprecated_function_calls, deprecated_functions]}.


### PR DESCRIPTION
When github allows public and anonymous access to code, use that
rather than relying on access through the 'git' account. Also,
many systems like the Mac OS X ship with broken or incomplete ssh
implementations; in this case the lack of /usr/libexec/ssh-askpass
which makes fetching dependencies a not so happy experience as
reps simply fail to download.
