### PR TITLE
Changed rebar.conf dependencies version tags

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -22,8 +22,8 @@
   {lager,       ".*",  {git, "git://github.com/basho/lager.git",     "2.0.3"}},
   {sync,        "0.*", {git, "git://github.com/rustyio/sync.git",      "HEAD"}},
   {jiffy,       ".*",  {git, "git://github.com/davisp/jiffy.git",      "0.13.2"}},
-  {shotgun,     ".*",  {git, "git://github.com/inaka/shotgun",         "0.1.4"}},
-  {worker_pool, ".*",  {git, "git://github.com/inaka/worker_pool.git", "1.0"}}
+  {shotgun,     ".*",  {git, "git://github.com/inaka/shotgun",         "master"}},
+  {worker_pool, ".*",  {git, "git://github.com/inaka/worker_pool.git", "master"}}
 ]}.
 {xref_warnings, true}.
 {xref_checks, [undefined_function_calls, undefined_functions, locals_not_used, deprecated_function_calls, deprecated_functions]}.


### PR DESCRIPTION
Changed rebar.conf dependencies version tags, as they require github account validation.