### PR TITLE
[#40] Fix for rebar.config dependency (changed to rustyio/sync)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,7 @@
   warn_untyped_record, debug_info
 ]}.
 {deps, [
-  {sync,        "0.*", {git, "git://github.com/inaka/sync.git",        "0.1.3"}},
+  {sync,        "0.*", {git, "git://github.com/rustyio/sync.git",      "475d728a"}},
   {jiffy,       ".*",  {git, "git://github.com/davisp/jiffy.git",      "0.13.3"}},
   {shotgun,     ".*",  {git, "git://github.com/inaka/shotgun.git",     "0.1.11"}},
   {worker_pool, ".*",  {git, "git://github.com/inaka/worker_pool.git", "1.0.2"}}


### PR DESCRIPTION
I had an issue that adding sumo_db as dependency requires tirerl which has dependency to inexistent inaka/sync. So I've changed this dependency to the same as in Makefile. It helped me on my local machine.