### PR TITLE
tirerl_worker accepts proplists, not tuple

### DIFF
--- a/src/tirerl_sup.erl
+++ b/src/tirerl_sup.erl
@@ -30,7 +30,7 @@ start_pool(Name, Opts) ->
     WPoolOptions  = [{overrun_warning, infinity},
                      {overrun_handler, {error_logger, warning_report}},
                      {workers, 50},
-                     {worker, {tirerl_worker, {Name, Opts}}}
+                     {worker, {tirerl_worker, [{Name, Opts}]}}
                     ],
 
     PoolSpec = {Name,


### PR DESCRIPTION


1) `tirerl_worker:init/1` is expecting a proplist: https://github.com/inaka/tirerl/blob/master/src/tirerl_worker.erl#L71
2) which gets called by `tirerl_worker:connection/1`
https://github.com/inaka/tirerl/blob/master/src/tirerl_worker.erl#L113

3) the caller `tirerl_sup:start_pool/2` should supply a proplist
https://github.com/inaka/tirerl/blob/master/src/tirerl_sup.erl#L33
