### PR TITLE
Fix request path of delete_by_query action

### DIFF
--- a/src/tirerl.hrl
+++ b/src/tirerl.hrl
@@ -13,6 +13,7 @@
 -define(MGET, <<"_mget">>).
 -define(COUNT, <<"_count">>).
 -define(QUERY, <<"_query">>).
+-define(DELETE_BY_QUERY, <<"_delete_by_query">>).
 -define(OPTIMIZE, <<"_optimize">>).
 -define(SEGMENTS, <<"_segments">>).
 -define(CLEAR_CACHE, <<"_cache/clear">>).

--- a/src/tirerl_worker.erl
+++ b/src/tirerl_worker.erl
@@ -223,7 +223,7 @@ make_request({count, Index, Type, Doc, Params}) ->
 make_request({delete_by_query, Index, Type, Doc, Params}) ->
     IndexList = join(Index, <<", ">>),
     TypeList = join(Type, <<", ">>),
-    Uri = make_uri([IndexList, TypeList, ?QUERY], Params),
+    Uri = make_uri([IndexList, TypeList, ?DELETE_BY_QUERY], Params),
     #{method => post, uri => Uri, body => Doc};
 
 make_request({is_index, Index}) ->


### PR DESCRIPTION
HTTP request path for `delete_by_query` action was incorrect. Per https://www.elastic.co/guide/en/elasticsearch/reference/6.2/docs-delete-by-query.html, the correct path is `_delete_by_query`.