### PR TITLE
Add content type 'application/json' to request header

### DIFF
--- a/src/tirerl_worker.erl
+++ b/src/tirerl_worker.erl
@@ -113,7 +113,8 @@ code_change(_OldVsn, State, _Extra) ->
 do_request(Req, #{base_url := BaseUrl}) ->
     #{method := Method, uri := Uri} = Req,
     Body = maps:get(body, Req, <<>>),
-    Headers = maps:get(headers, Req, []),
+    Headers = maps:get(headers, Req,
+                       [{<<"Content-Type">>, <<"application/json">>}]),
 
     Body1 = case Body of
                 Body when is_binary(Body) -> Body;


### PR DESCRIPTION
Since elasticsearch version 6.x, all json requests must have the correct header: `application/json'. Otherwise the server will reject the request with: 

```
HTTP/1.1 406 Not Acceptable
content-type: application/json; charset=UTF-8
content-length: 88
{"error":"Content-Type header [application/octet-stream] is not supported","status":406}
```